### PR TITLE
github-workflow: add GitHub workflow scope

### DIFF
--- a/GitHub.Authentication/Src/TokenScope.cs
+++ b/GitHub.Authentication/Src/TokenScope.cs
@@ -135,6 +135,14 @@ namespace GitHub.Authentication
         /// </summary>
         public static readonly TokenScope UserFollow = new TokenScope("user:follow");
 
+        /// <summary>
+        /// Grants the ability to add and update GitHub Actions workflow files.
+        /// Workflow files can be committed without this scope if the same file
+        /// (with both the same path and contents) exists on another branch in
+        /// the same repository.
+        /// </summary>
+        public static readonly TokenScope Workflow = new TokenScope("workflow");
+
         private TokenScope(string value)
             : base(value)
         { }
@@ -165,6 +173,7 @@ namespace GitHub.Authentication
             yield return User;
             yield return UserEmail;
             yield return UserFollow;
+            yield return Workflow;
             yield break;
         }
 

--- a/Shared/Cli/Program.cs
+++ b/Shared/Cli/Program.cs
@@ -80,7 +80,7 @@ namespace Microsoft.Alm.Cli
         internal const string SecretsNamespace = "git";
 
         internal static readonly Azure.TokenScope DevOpsCredentialScope = Azure.TokenScope.CodeWrite | Azure.TokenScope.PackagingRead;
-        internal static readonly Github.TokenScope GitHubCredentialScope = Github.TokenScope.Gist | Github.TokenScope.Repo;
+        internal static readonly Github.TokenScope GitHubCredentialScope = Github.TokenScope.Gist | Github.TokenScope.Repo | Github.TokenScope.Workflow;
 
         internal BasicCredentialPromptDelegate _basicCredentialPrompt = ConsoleFunctions.CredentialPrompt;
         internal BitbucketCredentialPromptDelegate _bitbucketCredentialPrompt = BitbucketFunctions.CredentialPrompt;


### PR DESCRIPTION
Add the 'workflow' scope to all GitHub PAT requests.
The new scope is required to be able to push updates containing changes
to/new workflow files.